### PR TITLE
Added Vendor and Product IDs for  Netgear A6100

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -285,6 +285,8 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	/*=== Customer ID ===*/
 	{USB_DEVICE(0x7392, 0xA811),.driver_info = RTL8821}, /* Edimax - Edimax */
 	{USB_DEVICE(0x2001, 0x3314),.driver_info = RTL8821}, /* D-Link - Cameo */
+	{USB_DEVICE(0x0846, 0x9052),.driver_info = RTL8821}, /* Netgear - A6100 */
+
 #endif
 
 #ifdef CONFIG_RTL8192E


### PR DESCRIPTION
While trying to get my new WiFi-USB-Stick running I cam across this project. Only the addition of the new Vendor and Product  ID was necessary to make it working. :)

Credits actually go to the German Ubuntu forums (specifically user elektronenblitz63). He made the changes and offered an alternative download but apparently never got around sending it to upstream.

Source: http://forum.ubuntuusers.de/topic/problem-mit-netgear-wlan-mini-adapter-wps-a610/#post-6222752 (German)
