### PR TITLE
Add note about building for something other than a PC, e.g. a RasPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ functions in favor of the new `proc_create()` function.
 
 ### Building
 
+The Makefile is preconfigured to handle most x86/PC versions.  If you are compiling for something other than an intel x86 architecture, you need to first select the platform, e.g. for the Raspberry Pi, you need to set the I386 to n and the ARM_RPI to y:
+```sh
+...
+CONFIG_PLATFORM_I386_PC = n
+...
+CONFIG_PLATFORM_ARM_RPI = y
+```
+
+There are many other platforms supported and some other advanced options, e.g. PCI instead of USB, but most won't be needed.
+
 The driver is built by running `make`, and can be tested by loading the
 built module using `insmod`:
 


### PR DESCRIPTION
The Makefile is configured by settings on top, not by trying to completely determine the target from the kernel tree or other things, and some other options.  For a normal USB adapter on a PC, just type "make", for anything else, it needs the options changed.  The added section explains it.
