### PR TITLE
Fix rtw_android.c to build on Linux >= 4.0-rc1

### DIFF
--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -30,6 +30,10 @@
 #endif
 #endif /* defined(RTW_ENABLE_WIFI_CONTROL_FUNC) */
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0))
+#define strnicmp strncasecmp
+#endif
+
 const char *android_wifi_cmd_str[ANDROID_WIFI_CMD_MAX] = {
 	"START",
 	"STOP",


### PR DESCRIPTION
In Linux 3.18, strnicmp was renamed to strncasecmp and in 4.0 was removed altogether.