### PR TITLE
Don't try to process rate section 0 in 5ghz bank. CCK is not used her…

### DIFF
--- a/hal/rtl8812a/rtl8812a_phycfg.c
+++ b/hal/rtl8812a/rtl8812a_phycfg.c
@@ -915,7 +915,7 @@ PHY_ConvertPowerLimitToPowerIndex(
 					else
 						channel = 51; // index of chnl 173 in chanl5G
 						
-					for ( rateSection = 0; rateSection < MAX_5G_RATE_SECTION_NUM; ++rateSection )
+					for ( rateSection = 1; rateSection < MAX_5G_RATE_SECTION_NUM; ++rateSection )
 					{	
 						if ( pHalData->odmpriv.PhyRegPgValueType == PHY_REG_PG_EXACT_VALUE ) {
 							// obtain the base dBm values in 5G band


### PR DESCRIPTION
…e, but by processing 0, baseIndex5G is left unset and can cause a kernel OOPS that looks like:

May 31 23:01:08 rpi2 kernel: [ 2045.373494] RTL871X: No power limit table of the specified band 1, bandwidth 0, ratesection 0, group 0, rf path 0
May 31 23:01:08 rpi2 kernel: [ 2045.373505] RTL871X: use other value 63
May 31 23:01:08 rpi2 kernel: [ 2045.373541] Unable to handle kernel paging request at virtual address 65ce6217
May 31 23:01:08 rpi2 kernel: [ 2045.375393] pgd = b2f98000
May 31 23:01:08 rpi2 kernel: [ 2045.375482] [65ce6217] *pgd=00000000
May 31 23:01:08 rpi2 kernel: [ 2045.375611] Internal error: Oops: 5 [#1] PREEMPT SMP ARM
May 31 23:01:08 rpi2 kernel: [ 2045.376276] CPU: 0 PID: 1311 Comm: wpa_supplicant Tainted: G           O   3.18.0-23-rpi2 #24-Ubuntu
May 31 23:01:08 rpi2 kernel: [ 2045.376450] task: b2fe5280 ti: a198c000 task.ti: a198c000
May 31 23:01:08 rpi2 kernel: [ 2045.376724] PC is at PHY_ConvertPowerLimitToPowerIndex+0x540/0x9e8 [8812au]
May 31 23:01:08 rpi2 kernel: [ 2045.376984] LR is at PHY_ConvertPowerLimitToPowerIndex+0x528/0x9e8 [8812au]
May 31 23:01:08 rpi2 kernel: [ 2045.377121] pc : [<7f15493c>]    lr : [<7f154924>]    psr: 600b0013
May 31 23:01:08 rpi2 kernel: [ 2045.377121] sp : a198dd10  ip : 80913bf0  fp : 0000345c
May 31 23:01:08 rpi2 kernel: [ 2045.377330] r10: 00000000  r9 : 00000000  r8 : b2e72872
May 31 23:01:08 rpi2 kernel: [ 2045.377433] r7 : b2e70000  r6 : b2e72872  r5 : 00000000  r4 : 0000003f
May 31 23:01:08 rpi2 kernel: [ 2045.377559] r3 : 65ce6215  r2 : 00000001  r1 : b2e73450  r0 : 0000001b
May 31 23:01:08 rpi2 kernel: [ 2045.377685] Flags: nZCv  IRQs on  FIQs on  Mode SVC_32  ISA ARM  Segment user
May 31 23:01:08 rpi2 kernel: [ 2045.377821] Control: 10c5387d  Table: 32f9806a  DAC: 00000015
May 31 23:01:08 rpi2 kernel: [ 2045.377933] Process wpa_supplicant (pid: 1311, stack limit = 0xa198c238)