### PR TITLE
core/rtw_br_ext: include definition of csum_ipv6_magic

### DIFF
--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -49,6 +49,7 @@
 #include <linux/icmpv6.h>
 #include <net/ndisc.h>
 #include <net/checksum.h>
+#include <net/ip6_checksum.h>
 #endif
 #endif
 


### PR DESCRIPTION
Fixes the following error observed while compiling this driver on arm64
against a v4.2.24 Linux kernel source tree.

core/rtw_br_ext.c:1447:9: error: implicit declaration of function
‘csum_ipv6_magic’ [-Werror=implicit-function-declaration]

Signed-off-by: Tyler Baker <tyler.baker@linaro.org>