### PR TITLE
Fix for kernel 4.11+ compile failure

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -46,6 +46,9 @@
 #endif
 	#include <linux/sem.h>
 	#include <linux/sched.h>
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0))
+	#include <linux/sched/signal.h>
+#endif
 	#include <linux/etherdevice.h>
 	#include <linux/wireless.h>
 	#include <net/iw_handler.h>


### PR DESCRIPTION
Signal related functions (flush_signal, allow_signal and
signal_pending) moved from include/linux/sched.h to
include/linux/sched/signal.h in 4.11.0:

http://elixir.free-electrons.com/linux/v4.10.17/source/include/linux/sched/signal.h

As a result, this module did not build in 4.11 on my Arch system.

This updates the includes to allow this module to build on 4.11.

I'm no kernel hacker, as this is my first time touching driver code. But I built the module locally and confirmed I could connect to my own wifi after this change was made, while previously compilation failed with the following error:

```
DKMS make.log for rtl8812au-r68.92875e4 for kernel 4.11.2-1-ARCH (x86_64)
Wed May 24 20:12:11 IST 2017
make ARCH=x86_64 CROSS_COMPILE= -C /lib/modules/4.11.2-1-ARCH/build M=/var/lib/dkms/rtl8812au/r68.92875e4/build  modules
make[1]: Entering directory '/usr/lib/modules/4.11.2-1-ARCH/build'
  CC [M]  /var/lib/dkms/rtl8812au/r68.92875e4/build/core/rtw_cmd.o
In file included from /var/lib/dkms/rtl8812au/r68.92875e4/build/include/drv_types.h:32:0,
                 from /var/lib/dkms/rtl8812au/r68.92875e4/build/core/rtw_cmd.c:22:
/var/lib/dkms/rtl8812au/r68.92875e4/build/include/osdep_service.h: In function 'thread_enter':
/var/lib/dkms/rtl8812au/r68.92875e4/build/include/osdep_service.h:251:2: error: implicit declaration of function 'allow_signal' [-Werror=implicit-function-declaration]
  allow_signal(SIGTERM);
  ^~~~~~~~~~~~
/var/lib/dkms/rtl8812au/r68.92875e4/build/include/osdep_service.h: In function 'flush_signals_thread':
/var/lib/dkms/rtl8812au/r68.92875e4/build/include/osdep_service.h:261:6: error: implicit declaration of function 'signal_pending' [-Werror=implicit-function-declaration]
  if (signal_pending (current))
      ^~~~~~~~~~~~~~
/var/lib/dkms/rtl8812au/r68.92875e4/build/include/osdep_service.h:263:3: error: implicit declaration of function 'flush_signals' [-Werror=implicit-function-declaration]
   flush_signals(current);
   ^~~~~~~~~~~~~
cc1: some warnings being treated as errors
make[2]: *** [scripts/Makefile.build:295: /var/lib/dkms/rtl8812au/r68.92875e4/build/core/rtw_cmd.o] Error 1
make[1]: *** [Makefile:1492: _module_/var/lib/dkms/rtl8812au/r68.92875e4/build] Error 2
make[1]: Leaving directory '/usr/lib/modules/4.11.2-1-ARCH/build'
make: *** [Makefile:1052: modules] Error 2
```
