### PR TITLE
Use $kernelver variable from dkms.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -652,7 +652,7 @@ EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
 SUBARCH := $(shell uname -m | sed -e s/i.86/i386/)
 ARCH ?= $(SUBARCH)
 CROSS_COMPILE ?=
-KVER  := $(shell uname -r)
+KVER ?= $(shell uname -r)
 KSRC := /lib/modules/$(KVER)/build
 MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
 INSTALL_PREFIX :=
@@ -664,7 +664,7 @@ EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_ANDROID -DCONFIG_PLATFO
 ARCH := $(R_ARCH)
 #CROSS_COMPILE := arm-none-linux-gnueabi-
 CROSS_COMPILE := $(R_CROSS_COMPILE)
-KVER:= 3.4.0
+KVER ?= 3.4.0
 #KSRC := ../../../../build/out/kernel
 KSRC := $(KERNEL_BUILD_PATH)
 MODULE_NAME :=wlan
@@ -681,8 +681,8 @@ ifeq ($(CONFIG_PLATFORM_MSTAR_TITANIA12), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_MSTAR_TITANIA12
 ARCH:=mips
 CROSS_COMPILE:= /usr/src/Mstar_kernel/mips-4.3/bin/mips-linux-gnu-
-KVER:= 2.6.28.9
-KSRC:= /usr/src/Mstar_kernel/2.6.28.9/
+KVER ?= 2.6.28.9
+KSRC := /usr/src/Mstar_kernel/2.6.28.9/
 endif
 
 ifeq ($(CONFIG_PLATFORM_ANDROID_X86), y)
@@ -710,7 +710,7 @@ ifeq ($(CONFIG_PLATFORM_ARM_PXA2XX), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
 ARCH := arm
 CROSS_COMPILE := arm-none-linux-gnueabi-
-KVER  := 2.6.34.1
+KVER ?= 2.6.34.1
 KSRC ?= /usr/src/linux-2.6.34.1
 endif
 
@@ -718,7 +718,7 @@ ifeq ($(CONFIG_PLATFORM_ARM_S3C2K4), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
 ARCH := arm
 CROSS_COMPILE := arm-linux-
-KVER  := 2.6.24.7_$(ARCH)
+KVER ?= 2.6.24.7_$(ARCH)
 KSRC := /usr/src/kernels/linux-$(KVER)
 endif
 
@@ -726,7 +726,7 @@ ifeq ($(CONFIG_PLATFORM_ARM_S3C6K4), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
 ARCH := arm
 CROSS_COMPILE := arm-none-linux-gnueabi-
-KVER  := 2.6.34.1
+KVER ?= 2.6.34.1
 KSRC ?= /usr/src/linux-2.6.34.1
 endif
 
@@ -734,7 +734,7 @@ ifeq ($(CONFIG_PLATFORM_ARM_RPI), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
 ARCH := arm
 CROSS_COMPILE := 
-KVER  := $(shell uname -r)
+KVER ?= $(shell uname -r)
 KSRC ?= /lib/modules/$(KVER)/build
 MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
 endif
@@ -743,7 +743,7 @@ ifeq ($(CONFIG_PLATFORM_RTD2880B), y)
 EXTRA_CFLAGS += -DCONFIG_BIG_ENDIAN -DCONFIG_PLATFORM_RTD2880B
 ARCH:=
 CROSS_COMPILE:=
-KVER:=
+KVER ?=
 KSRC:=
 endif
 
@@ -751,7 +751,7 @@ ifeq ($(CONFIG_PLATFORM_MIPS_RMI), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
 ARCH:=mips
 CROSS_COMPILE:=mipsisa32r2-uclibc-
-KVER:=
+KVER ?=
 KSRC:= /root/work/kernel_realtek
 endif
 
@@ -759,7 +759,7 @@ ifeq ($(CONFIG_PLATFORM_MIPS_PLM), y)
 EXTRA_CFLAGS += -DCONFIG_BIG_ENDIAN
 ARCH:=mips
 CROSS_COMPILE:=mipsisa32r2-uclibc-
-KVER:=
+KVER ?=
 KSRC:= /root/work/kernel_realtek
 endif
 
@@ -767,7 +767,7 @@ ifeq ($(CONFIG_PLATFORM_MSTAR389), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_MSTAR389
 ARCH:=mips
 CROSS_COMPILE:= mips-linux-gnu-
-KVER:= 2.6.28.10
+KVER ?= 2.6.28.10
 KSRC:= /home/mstar/mstar_linux/2.6.28.9/
 endif
 
@@ -790,7 +790,7 @@ ifeq ($(CONFIG_PLATFORM_RTK_DMP), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DRTK_DMP_PLATFORM
 ARCH:=mips
 CROSS_COMPILE:=mipsel-linux-
-KVER:=
+KVER ?=
 KSRC ?= /usr/src/DMP_Kernel/jupiter/linux-2.6.12
 endif
 
@@ -798,7 +798,7 @@ ifeq ($(CONFIG_PLATFORM_MT53XX), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_MT53XX
 ARCH:= arm
 CROSS_COMPILE:= arm11_mtk_le-
-KVER:= 2.6.27
+KVER ?= 2.6.27
 KSRC?= /proj/mtk00802/BD_Compare/BDP/Dev/BDP_V301/BDP_Linux/linux-2.6.27
 endif
 
@@ -806,7 +806,7 @@ ifeq ($(CONFIG_PLATFORM_ARM_MX51_241H), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_WISTRON_PLATFORM
 ARCH := arm
 CROSS_COMPILE := /opt/freescale/usr/local/gcc-4.1.2-glibc-2.5-nptl-3/arm-none-linux-gnueabi/bin/arm-none-linux-gnueabi-
-KVER  := 2.6.31
+KVER ?= 2.6.31
 KSRC ?= /lib/modules/2.6.31-770-g0e46b52/source
 endif
 
@@ -823,7 +823,7 @@ ifeq ($(CONFIG_PLATFORM_ACTIONS_ATJ227X), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_ACTIONS_ATJ227X
 ARCH := mips
 CROSS_COMPILE := /home/cnsd4/project/actions/tools-2.6.27/bin/mipsel-linux-gnu-
-KVER  := 2.6.27
+KVER ?= 2.6.27
 KSRC := /home/cnsd4/project/actions/linux-2.6.27.28
 endif
 
@@ -831,7 +831,7 @@ ifeq ($(CONFIG_PLATFORM_TI_DM365), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_TI_DM365
 ARCH := arm
 CROSS_COMPILE := /home/cnsd4/Appro/mv_pro_5.0/montavista/pro/devkit/arm/v5t_le/bin/arm_v5t_le-
-KVER  := 2.6.18
+KVER ?= 2.6.18
 KSRC := /home/cnsd4/Appro/mv_pro_5.0/montavista/pro/devkit/lsp/ti-davinci/linux-dm365
 endif
 
@@ -926,7 +926,7 @@ ifeq ($(CONFIG_PLATFORM_SZEBOOK), y)
 EXTRA_CFLAGS += -DCONFIG_BIG_ENDIAN
 ARCH:=arm
 CROSS_COMPILE:=/opt/crosstool2/bin/armeb-unknown-linux-gnueabi- 
-KVER:= 2.6.31.6
+KVER ?= 2.6.31.6
 KSRC:= ../code/linux-2.6.31.6-2020/
 endif
 
@@ -935,7 +935,7 @@ ifeq ($(CONFIG_PLATFORM_MN10300), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_MN10300
 ARCH := mn10300
 CROSS_COMPILE := mn10300-linux-
-KVER := 2.6.32.2
+KVER ?= 2.6.32.2
 KSRC := /home/winuser/work/Plat_sLD2T_V3010/usr/src/linux-2.6.32.2
 INSTALL_PREFIX :=
 endif
@@ -945,7 +945,7 @@ ifeq ($(CONFIG_PLATFORM_ARM_SUNxI), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_ARM_SUNxI
 ARCH := arm
 CROSS_COMPILE := arm-none-linux-gnueabi-
-KVER  := 3.0.8
+KVER ?= 3.0.8
 #KSRC:= ../lichee/linux-3.0/
 endif
 
@@ -959,7 +959,7 @@ EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
 EXTRA_CFLAGS += -DCONFIG_P2P_IPS
 ARCH := arm
 CROSS_COMPILE := arm-none-linux-gnueabi-
-KVER  := 3.3.0
+KVER ?= 3.3.0
 #KSRC:= ../lichee/linux-3.3/
 endif
 
@@ -967,7 +967,7 @@ ifeq ($(CONFIG_PLATFORM_ACTIONS_ATV5201), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_ACTIONS_ATV5201
 ARCH := mips
 CROSS_COMPILE := mipsel-linux-gnu-
-KVER  := $(KERNEL_VER)
+KVER ?= $(KERNEL_VER)
 KSRC:= $(CFGDIR)/../../kernel/linux-$(KERNEL_VER)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -664,7 +664,7 @@ EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_ANDROID -DCONFIG_PLATFO
 ARCH := $(R_ARCH)
 #CROSS_COMPILE := arm-none-linux-gnueabi-
 CROSS_COMPILE := $(R_CROSS_COMPILE)
-KVER ?= 3.4.0
+KVER := 3.4.0
 #KSRC := ../../../../build/out/kernel
 KSRC := $(KERNEL_BUILD_PATH)
 MODULE_NAME :=wlan
@@ -681,7 +681,7 @@ ifeq ($(CONFIG_PLATFORM_MSTAR_TITANIA12), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_MSTAR_TITANIA12
 ARCH:=mips
 CROSS_COMPILE:= /usr/src/Mstar_kernel/mips-4.3/bin/mips-linux-gnu-
-KVER ?= 2.6.28.9
+KVER := 2.6.28.9
 KSRC := /usr/src/Mstar_kernel/2.6.28.9/
 endif
 
@@ -710,7 +710,7 @@ ifeq ($(CONFIG_PLATFORM_ARM_PXA2XX), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
 ARCH := arm
 CROSS_COMPILE := arm-none-linux-gnueabi-
-KVER ?= 2.6.34.1
+KVER := 2.6.34.1
 KSRC ?= /usr/src/linux-2.6.34.1
 endif
 
@@ -718,7 +718,7 @@ ifeq ($(CONFIG_PLATFORM_ARM_S3C2K4), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
 ARCH := arm
 CROSS_COMPILE := arm-linux-
-KVER ?= 2.6.24.7_$(ARCH)
+KVER := 2.6.24.7_$(ARCH)
 KSRC := /usr/src/kernels/linux-$(KVER)
 endif
 
@@ -726,7 +726,7 @@ ifeq ($(CONFIG_PLATFORM_ARM_S3C6K4), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
 ARCH := arm
 CROSS_COMPILE := arm-none-linux-gnueabi-
-KVER ?= 2.6.34.1
+KVER := 2.6.34.1
 KSRC ?= /usr/src/linux-2.6.34.1
 endif
 
@@ -767,7 +767,7 @@ ifeq ($(CONFIG_PLATFORM_MSTAR389), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_MSTAR389
 ARCH:=mips
 CROSS_COMPILE:= mips-linux-gnu-
-KVER ?= 2.6.28.10
+KVER := 2.6.28.10
 KSRC:= /home/mstar/mstar_linux/2.6.28.9/
 endif
 
@@ -798,7 +798,7 @@ ifeq ($(CONFIG_PLATFORM_MT53XX), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_MT53XX
 ARCH:= arm
 CROSS_COMPILE:= arm11_mtk_le-
-KVER ?= 2.6.27
+KVER := 2.6.27
 KSRC?= /proj/mtk00802/BD_Compare/BDP/Dev/BDP_V301/BDP_Linux/linux-2.6.27
 endif
 
@@ -806,7 +806,7 @@ ifeq ($(CONFIG_PLATFORM_ARM_MX51_241H), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_WISTRON_PLATFORM
 ARCH := arm
 CROSS_COMPILE := /opt/freescale/usr/local/gcc-4.1.2-glibc-2.5-nptl-3/arm-none-linux-gnueabi/bin/arm-none-linux-gnueabi-
-KVER ?= 2.6.31
+KVER := 2.6.31
 KSRC ?= /lib/modules/2.6.31-770-g0e46b52/source
 endif
 
@@ -823,7 +823,7 @@ ifeq ($(CONFIG_PLATFORM_ACTIONS_ATJ227X), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_ACTIONS_ATJ227X
 ARCH := mips
 CROSS_COMPILE := /home/cnsd4/project/actions/tools-2.6.27/bin/mipsel-linux-gnu-
-KVER ?= 2.6.27
+KVER := 2.6.27
 KSRC := /home/cnsd4/project/actions/linux-2.6.27.28
 endif
 
@@ -831,7 +831,7 @@ ifeq ($(CONFIG_PLATFORM_TI_DM365), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_TI_DM365
 ARCH := arm
 CROSS_COMPILE := /home/cnsd4/Appro/mv_pro_5.0/montavista/pro/devkit/arm/v5t_le/bin/arm_v5t_le-
-KVER ?= 2.6.18
+KVER := 2.6.18
 KSRC := /home/cnsd4/Appro/mv_pro_5.0/montavista/pro/devkit/lsp/ti-davinci/linux-dm365
 endif
 
@@ -926,7 +926,7 @@ ifeq ($(CONFIG_PLATFORM_SZEBOOK), y)
 EXTRA_CFLAGS += -DCONFIG_BIG_ENDIAN
 ARCH:=arm
 CROSS_COMPILE:=/opt/crosstool2/bin/armeb-unknown-linux-gnueabi- 
-KVER ?= 2.6.31.6
+KVER := 2.6.31.6
 KSRC:= ../code/linux-2.6.31.6-2020/
 endif
 
@@ -935,7 +935,7 @@ ifeq ($(CONFIG_PLATFORM_MN10300), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_MN10300
 ARCH := mn10300
 CROSS_COMPILE := mn10300-linux-
-KVER ?= 2.6.32.2
+KVER := 2.6.32.2
 KSRC := /home/winuser/work/Plat_sLD2T_V3010/usr/src/linux-2.6.32.2
 INSTALL_PREFIX :=
 endif
@@ -945,7 +945,7 @@ ifeq ($(CONFIG_PLATFORM_ARM_SUNxI), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_ARM_SUNxI
 ARCH := arm
 CROSS_COMPILE := arm-none-linux-gnueabi-
-KVER ?= 3.0.8
+KVER := 3.0.8
 #KSRC:= ../lichee/linux-3.0/
 endif
 
@@ -959,7 +959,7 @@ EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
 EXTRA_CFLAGS += -DCONFIG_P2P_IPS
 ARCH := arm
 CROSS_COMPILE := arm-none-linux-gnueabi-
-KVER ?= 3.3.0
+KVER := 3.3.0
 #KSRC:= ../lichee/linux-3.3/
 endif
 
@@ -967,7 +967,7 @@ ifeq ($(CONFIG_PLATFORM_ACTIONS_ATV5201), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_ACTIONS_ATV5201
 ARCH := mips
 CROSS_COMPILE := mipsel-linux-gnu-
-KVER ?= $(KERNEL_VER)
+KVER := $(KERNEL_VER)
 KSRC:= $(CFGDIR)/../../kernel/linux-$(KERNEL_VER)
 endif
 

--- a/dkms.conf
+++ b/dkms.conf
@@ -4,6 +4,6 @@ PACKAGE_VERSION=4.2.2
 DEST_MODULE_LOCATION=/kernel/drivers/net/wireless
 BUILT_MODULE_NAME=8812au
 
-MAKE="'make'  all"
+MAKE="'make' all KVER=$kernelver"
 CLEAN="'make' clean"
 AUTOINSTALL="yes"


### PR DESCRIPTION
This commit will enable forwarding the kernel-version passed to dkms via the -k flag to the Makefile.

Currently, compiling this driver with dkms is not working properly. 

During compilation, the Makefile always uses "uname -r" (at least for i386 and RPi), which is the kernel version currently running. But most of the time, dkms is ran trough hooks after kernel updates. Dkms then will compile the driver for the old kernel, resulting in either an error (e.g. in case of Arch, because the old kernel headers are removed) and/or leaving the new kernel without the driver (e.g. in Ubuntu), which ends up with the device not working after reboot.