### PR TITLE
usb device support: Tenda U12 dongle

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -279,6 +279,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	{USB_DEVICE(0x2357, 0x0101),.driver_info = RTL8812}, /* TP-Link - Archer T4U */
 	{USB_DEVICE(0x0411, 0x025d),.driver_info = RTL8812}, /* Buffalo - WI-U3-866D */
 	{USB_DEVICE(0x0bda, 0x8812),.driver_info = RTL8812}, /* Netis WF2190 */
+	{USB_DEVICE(0x2604, 0x0012),.driver_info = RTL8812}, /* Tenda U12 */
 #endif
 
 #ifdef CONFIG_RTL8821A


### PR DESCRIPTION
This commit adds support to the Tenda U12 ac USB dongle.

Signed-off-by: Carlos Miguel Ferreira <carlosmf.pt@gmail.com>