### PR TITLE
Add USB Device I-O DATA WNPU583B with 0bda:0823

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -303,6 +303,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	{USB_DEVICE(0x0BDA, 0xA811),.driver_info = RTL8821}, /* GMYLE - AC450 */
 	{USB_DEVICE(0x2001, 0x3318),.driver_info = RTL8821}, /* D-Link - DWA-172 */
 	{USB_DEVICE(0x3823, 0x6249),.driver_info = RTL8821}, /* Obihai - OBiWiFi */
+	{USB_DEVICE(0x0bda, 0x0823),.driver_info = RTL8821}, /* I-O DATA - WNPU583B */
 #endif
 
 #ifdef CONFIG_RTL8192E


### PR DESCRIPTION
I own an [I-O DATA WNPU583B](https://www.iodata.jp/product/network/adp/wnpu583b/) (Japanese), which uses rtl8821a. I've confirmed that this patch makes the device work both on my Ubuntu 16.04 and 18.04 box.

## Kernel release and version

`uname -rv`

### 16.04

```
4.15.0-52-generic #56~16.04.1-Ubuntu SMP Thu Jun 6 12:03:31 UTC 2019
```

### 18.04

```
4.18.0-18-generic #19~18.04.1-Ubuntu SMP Fri Apr 5 10:22:13 UTC 2019
```