### PR TITLE
Address two -Wimplicit-fallthrough issues for gcc

### DIFF
--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -2069,6 +2069,7 @@ static int rtw_ap_set_key(_adapter *padapter, u8 *key, u8 alg, int keyid, u8 set
 		case _TKIP_WTMIC_:		
 		case _AES_:
 			keylen = 16;		
+			break;
 		default:
 			keylen = 16;		
 	}

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -709,7 +709,7 @@ void mgt_dispatcher(_adapter *padapter, union recv_frame *precv_frame)
 				ptable->func = &OnAuth;
 			else
 				ptable->func = &OnAuthClient;
-			//pass through
+			__attribute__ ((fallthrough));
 		case WIFI_ASSOCREQ:
 		case WIFI_REASSOCREQ:
 			_mgt_dispatcher(padapter, ptable, precv_frame);	


### PR DESCRIPTION
In rtw_mlme_ext.c, falling through makes perfect sense. I've
there replaced the ad hoc comment with the necessary gcc
attribute. In rtw_ap.c, the default case seems to agree with
the previous ones only by happenstance, so I've inserted an
actual break there. The warnings no longer fire.

Yes, there's a portable [[fallthrough]] -- for C++17. This
won't work on Clang, but neither will the kernel, nor this
Makefile.