### PR TITLE
Add mips64el loongson arch support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ CONFIG_PLATFORM_ARM_SUN6I = n
 CONFIG_PLATFORM_ACTIONS_ATM702X = n
 CONFIG_PLATFORM_ACTIONS_ATV5201 = n
 CONFIG_PLATFORM_PPC = n
+CONFIG_PLATFORM_MIPS64_LOONGSON = n
 
 CONFIG_DRVEXT_MODULE = n
 
@@ -985,6 +986,14 @@ KVER ?= $(shell uname -r)
 KSRC ?= /lib/modules/$(KVER)/build
 MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
 INSTALL_PREFIX :=
+endif
+
+ifeq ($(CONFIG_PLATFORM_MIPS64_LOONGSON), y)
+EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+ARCH := mips
+KVER ?= $(shell uname -r)
+KSRC ?= /lib/modules/$(KVER)/build
+MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
 endif
 
 


### PR DESCRIPTION
I tryed to add loongson arch support and it works well on loongson machines.