### PR TITLE
usb_intf: Add Volans VL-UW120S

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -284,6 +284,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	{USB_DEVICE(0x2357, 0x0122),.driver_info = RTL8812}, /* TP-Link - Archer T4UHP, AC1300 */
 	{USB_DEVICE(0x0411, 0x025d),.driver_info = RTL8812}, /* Buffalo - WI-U3-866D */
 	{USB_DEVICE(0x0bda, 0x8812),.driver_info = RTL8812}, /* Netis WF2190 */
+	{USB_DEVICE(0x0bda, 0xb812),.driver_info = RTL8812}, /* Volans VL-UW120S */
 	{USB_DEVICE(0x2604, 0x0012),.driver_info = RTL8812}, /* Tenda U12 */
 #endif
 


### PR DESCRIPTION
Volans produce a high-power dongle, the VL-UW120S which uses USB ID `0bda:b812`.

```
Bus 001 Device 005: ID 0bda:b812 Realtek Semiconductor Corp.
Device Descriptor:
  bLength                18
  bDescriptorType         1
  bcdUSB               2.10
  bDeviceClass            0
  bDeviceSubClass         0
  bDeviceProtocol         0
  bMaxPacketSize0        64
  idVendor           0x0bda Realtek Semiconductor Corp.
  idProduct          0xb812
  bcdDevice            2.10
  iManufacturer           1 Realtek
  iProduct                2 USB3.0 802.11ac 1200M Adapter
  iSerial                 3 123456
  bNumConfigurations      1
  Configuration Descriptor:
    bLength                 9
    bDescriptorType         2
    wTotalLength       0x0035
    bNumInterfaces          1
    bConfigurationValue     1
    iConfiguration          0
    bmAttributes         0x80
      (Bus Powered)
    MaxPower              500mA
    Interface Descriptor:
      bLength                 9
      bDescriptorType         4
      bInterfaceNumber        0
      bAlternateSetting       0
      bNumEndpoints           5
      bInterfaceClass       255 Vendor Specific Class
      bInterfaceSubClass    255 Vendor Specific Subclass
      bInterfaceProtocol    255 Vendor Specific Protocol
      iInterface              2 USB3.0 802.11ac 1200M Adapter
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x84  EP 4 IN
        bmAttributes            2
          Transfer Type            Bulk
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0200  1x 512 bytes
        bInterval               0
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x05  EP 5 OUT
        bmAttributes            2
          Transfer Type            Bulk
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0200  1x 512 bytes
        bInterval               0
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x06  EP 6 OUT
        bmAttributes            2
          Transfer Type            Bulk
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0200  1x 512 bytes
        bInterval               0
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x87  EP 7 IN
        bmAttributes            3
          Transfer Type            Interrupt
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0040  1x 64 bytes
        bInterval               3
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x08  EP 8 OUT
        bmAttributes            2
          Transfer Type            Bulk
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0200  1x 512 bytes
        bInterval               0
```

```
[  961.838247] usb 1-4: new high-speed USB device number 5 using xhci_hcd
[  961.994704] usb 1-4: New USB device found, idVendor=0bda, idProduct=b812, bcdDevice= 2.10
[  961.994710] usb 1-4: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[  961.994712] usb 1-4: Product: USB3.0 802.11ac 1200M Adapter
[  961.994713] usb 1-4: Manufacturer: Realtek
[  961.994715] usb 1-4: SerialNumber: 123456
[  962.078412] rtl8812au 1-4:1.0 enx00e04c870000: renamed from wlan0
```

```
Sep 29 14:00:17 wicen2 wpa_supplicant[496]: nl80211: Could not configure driver mode
Sep 29 14:00:17 wicen2 wpa_supplicant[496]: nl80211: deinit ifname=enx00e04c870000 disabled_11b_rates=0
Sep 29 14:00:17 wicen2 wpa_supplicant[496]: rfkill: Cannot get wiphy information
Sep 29 14:00:18 wicen2 wpa_supplicant[496]: Could not set interface enx00e04c870000 flags (UP): Operation not permitted
Sep 29 14:00:18 wicen2 wpa_supplicant[496]: WEXT: Could not set interface 'enx00e04c870000' UP
Sep 29 14:00:18 wicen2 wpa_supplicant[496]: enx00e04c870000: Failed to initialize driver interface
```

Both NetworkManager and `iw` seem to ignore the device, `wpa_supplicant` moans about it (, but it shows up in `ip link` and `iwconfig` (wow, hello 2003!).  Yet to see this dongle actually connect to a wireless network but this is promising, so I'll put this pull request here in draft.  If I get something going, I'll mark the PR as ready.