### PR TITLE
Fix compilation for kernel 5.15+

### DIFF
--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -22,7 +22,10 @@
 #ifdef __KERNEL__
 #include <linux/if_arp.h>
 #include <net/ip.h>
+#include <linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 #include <net/ipx.h>
+#endif
 #include <linux/atalk.h>
 #include <linux/udp.h>
 #include <linux/if_pppox.h>
@@ -170,7 +173,7 @@ static __inline__ void __nat25_generate_ipv4_network_addr(unsigned char *network
 	memcpy(networkAddr+7, (unsigned char *)ipAddr, 4);
 }
 
-
+#ifdef _NET_INET_IPX_H_
 static __inline__ void __nat25_generate_ipx_network_addr_with_node(unsigned char *networkAddr,
 				unsigned int *ipxNetAddr, unsigned char *ipxNodeAddr)
 {
@@ -191,7 +194,7 @@ static __inline__ void __nat25_generate_ipx_network_addr_with_socket(unsigned ch
 	memcpy(networkAddr+1, (unsigned char *)ipxNetAddr, 4);
 	memcpy(networkAddr+5, (unsigned char *)ipxSocketAddr, 2);
 }
-
+#endif
 
 static __inline__ void __nat25_generate_apple_network_addr(unsigned char *networkAddr,
 				unsigned short *network, unsigned char *node)
@@ -337,6 +340,7 @@ static __inline__ int __nat25_network_hash(unsigned char *networkAddr)
 
 		return x & (NAT25_HASH_SIZE - 1);
 	}
+	#ifdef _NET_INET_IPX_H_
 	else if(networkAddr[0] == NAT25_IPX)
 	{
 		unsigned long x;
@@ -346,6 +350,7 @@ static __inline__ int __nat25_network_hash(unsigned char *networkAddr)
 
 		return x & (NAT25_HASH_SIZE - 1);
 	}
+	#endif
 	else if(networkAddr[0] == NAT25_APPLE)
 	{
 		unsigned long x;
@@ -927,7 +932,7 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 				return -1;
 		}
 	}
-
+        #ifdef _NET_INET_IPX_H_
 	/*---------------------------------------------------*/
 	/*         Handle IPX and Apple Talk frame           */
 	/*---------------------------------------------------*/
@@ -1191,7 +1196,7 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 
 		return -1;
 	}
-
+        #endif
 	/*---------------------------------------------------*/
 	/*                Handle PPPoE frame                 */
 	/*---------------------------------------------------*/


### PR DESCRIPTION
Removed IPX support in kernel v5.15

Patch from https://github.com/aircrack-ng/rtl8812au/pull/898/commits/47a38b7c736dd9e9baac9eb07a6dceb83429fb49