### PR TITLE
fix compilation for linux kernel 5.17

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -146,7 +146,7 @@
 	typedef int		thread_return;
 	typedef void*	thread_context;
 
-	#define thread_exit() complete_and_exit(NULL, 0)
+	#define thread_exit() kthread_complete_and_exit(NULL, 0)
 
 	typedef void timer_hdl_return;
 	typedef void* timer_hdl_context;


### PR DESCRIPTION
complete_and_exit() got renamed to kthread_complete_and_exit().

https://lore.kernel.org/lkml/20211208202532.16409-8-ebiederm@xmission.com/
