### PR TITLE
Fix build on Ubuntu 22.04 / 5.15 kernel

### DIFF
--- a/core/rtw_cmd.c
+++ b/core/rtw_cmd.c
@@ -554,6 +554,9 @@ _func_exit_;
 
 	thread_exit();
 
+#ifdef PLATFORM_LINUX
+	return 0;
+#endif
 }
 
 

--- a/core/rtw_mp.c
+++ b/core/rtw_mp.c
@@ -1179,6 +1179,10 @@ exit:
 	pmptx->stop = 1;
 
 	thread_exit();
+
+#ifdef PLATFORM_LINUX
+	return 0;
+#endif
 }
 
 void fill_txdesc_for_mp(PADAPTER padapter, struct tx_desc *ptxdesc)

--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -146,7 +146,11 @@
 	typedef int		thread_return;
 	typedef void*	thread_context;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0))
 	#define thread_exit() kthread_complete_and_exit(NULL, 0)
+#else
+	#define thread_exit() complete_and_exit(NULL, 0)
+#endif
 
 	typedef void timer_hdl_return;
 	typedef void* timer_hdl_context;


### PR DESCRIPTION
Fix build errors on Ubuntu 22.04 / linux kernel 5.15:

```
$ make
make ARCH=x86_64 CROSS_COMPILE= -C /lib/modules/5.15.0-25-generic/build M=/home/ant/rtl8812au  modules
make[1]: Entering directory '/usr/src/linux-headers-5.15.0-25-generic'
  CC [M]  /home/ant/rtl8812au/core/rtw_cmd.o
/home/ant/rtl8812au/core/rtw_cmd.c: In function ‘rtw_cmd_thread’:
/home/ant/rtl8812au/core/rtw_cmd.c:557:1: error: control reaches end of non-void function [-Werror=return-type]
  557 | }
      | ^
...
  CC [M]  /home/ant/rtl8812au/core/rtw_mp.o
/home/ant/rtl8812au/core/rtw_mp.c: In function ‘mp_xmit_packet_thread’:
/home/ant/rtl8812au/core/rtw_mp.c:1182:1: error: no return statement in function returning non-void [-Werror=return-type]
 1182 | }
      | ^
cc1: some warnings being treated as errors
```

And:

```
  LD [M]  /home/ant/rtl8812au/8812au.o
  MODPOST /home/ant/rtl8812au/Module.symvers
ERROR: modpost: "kthread_complete_and_exit" [/home/ant/rtl8812au/8812au.ko] undefined!
make[2]: *** [scripts/Makefile.modpost:134: /home/ant/rtl8812au/Module.symvers] Error 1
```